### PR TITLE
Update to latest elf-council-proposals 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9634,7 +9634,7 @@
       }
     },
     "elf-council-proposals": {
-      "version": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-proposals.git#5b9fb1003e88565acf17c6179cd8146a483f2be1",
+      "version": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-proposals.git#e0223c9c61b081d08321716999e981bb477238ef",
       "from": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-proposals.git",
       "requires": {
         "@types/lodash.uniq": "^4.5.6",


### PR DESCRIPTION
This in an update to `elf-council-proposals` which fixes a bug in the snapshot proposal ids we were providing.

Updates from: https://github.com/element-fi/elf-council-proposals/commit/e0223c9c61b081d08321716999e981bb477238ef

UI and everything now works as expected for up to 3 proposals on the testnet:
![image](https://user-images.githubusercontent.com/4524175/138974745-c5ff268a-f3e5-44b3-a7f7-3b1c1ad50332.png)

