### PR TITLE
Fix scrolling issue with whole page

### DIFF
--- a/frontend/src/ui/app/PageView.tsx
+++ b/frontend/src/ui/app/PageView.tsx
@@ -19,27 +19,24 @@ export default function PageView(props: PageViewProps): ReactElement {
   const isWrongChain = !!chainId && chainId !== addressesJson.chainId;
   return (
     <Fragment>
-      <div>
-        <div className={tw("flex", "w-screen", "h-screen")}>
-          <Sidebar />
-          <div
-            className={tw(
-              "flex-1",
-              "h-screen",
-              "bg-gradient-to-b",
-              "from-gray-50",
-              "to-gray-100",
-              "p-6",
-              "space-y-6",
-              "overflow-scroll",
-              "justify-center",
-              "align-middle",
-              "items-center"
-            )}
-          >
-            <Header />
-            <div className={tw("max-w-6xl", "m-auto")}>{children}</div>
-          </div>
+      <div className={tw("w-full", "h-full", "md:pl-80", "overflow-hidden")}>
+        <Sidebar />
+        <div
+          className={tw(
+            "flex-1",
+            "h-full",
+            "p-6",
+            "overflow-scroll",
+            "justify-center",
+            "align-middle",
+            "items-center",
+            "bg-gradient-to-b",
+            "from-gray-50",
+            "to-gray-100"
+          )}
+        >
+          <Header />
+          <div className={tw("max-w-6xl", "mt-6", "m-auto")}>{children}</div>
         </div>
       </div>
       <SimpleDialog isOpen={isWrongChain}>

--- a/frontend/src/ui/app/Sidebar.tsx
+++ b/frontend/src/ui/app/Sidebar.tsx
@@ -25,7 +25,7 @@ export default function Sidebar(): ReactElement {
     <Fragment>
       <button
         className={tw(
-          "absolute",
+          "fixed",
           "h-12",
           "w-12",
           "top-0",
@@ -43,16 +43,15 @@ export default function Sidebar(): ReactElement {
       <div
         className={tw(
           "w-full",
+          "h-full",
           "ease-in-out",
           "transition-all",
           "duration-300",
           "z-30",
-          "h-screen",
           "fixed",
           "top-0",
           "left-0",
           "md:w-80",
-          "md:static",
           "bg-white",
           "transform-gpu",
           "md:translate-x-0",


### PR DESCRIPTION
Fixes the scrolling issue with the site where there was a bunch of extra room at the bottom.  the problem was with using `h-screen` which someone added another full screen of height.

The Sidebar is now fixed as well, so it won't scroll with the page.