### PR TITLE
Add accessibility & transition to DetailedDelegateProfile

### DIFF
--- a/src/ui/delegate/DelegatesList/DelegateProfile.tsx
+++ b/src/ui/delegate/DelegatesList/DelegateProfile.tsx
@@ -15,31 +15,31 @@ import DetailedDelegateProfile from "src/ui/delegate/DelegatesList/DetailedDeleg
 interface DelegateProfileProps {
   selected: boolean;
   delegate: Delegate;
-  setDelegateAddressInput?: (address: string) => void;
+  onChooseDelegate?: (address: string) => void;
   active?: boolean;
 }
 
-const defaultToolTipState = {
+const defaultTooltipState = {
   twitterHandle: false,
   address: false,
 };
 
 function DelegateProfile(props: DelegateProfileProps): ReactElement {
-  const { selected = false, delegate, setDelegateAddressInput } = props;
-  const [showToolTip, setshowToolTip] = useState(defaultToolTipState);
+  const { selected = false, delegate, onChooseDelegate } = props;
+  const [showTooltip, setShowTooltip] = useState(defaultTooltipState);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleCopy = useCallback(
+  const onCopy = useCallback(
     (type: "twitterHandle" | "address") => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
 
-      const nextState = { ...defaultToolTipState };
+      const nextState = { ...defaultTooltipState };
       nextState[type] = true;
-      setshowToolTip(nextState);
+      setShowTooltip(nextState);
       timeoutRef.current = setTimeout(() => {
-        setshowToolTip(defaultToolTipState);
+        setShowTooltip(defaultTooltipState);
         timeoutRef.current = null;
       }, ONE_SECOND_IN_MILLISECONDS);
       copyToClipboard(delegate[type]);
@@ -47,13 +47,14 @@ function DelegateProfile(props: DelegateProfileProps): ReactElement {
     [delegate],
   );
 
-  const handleCopyTwitterHandle = (e: React.MouseEvent) => {
+  const onCopyTwitterHandle = (e: React.MouseEvent) => {
     e.stopPropagation();
-    handleCopy("twitterHandle");
+    onCopy("twitterHandle");
   };
-  const handleCopyAddress = (e: React.MouseEvent) => {
+
+  const onCopyAddress = (e: React.MouseEvent) => {
     e.stopPropagation();
-    handleCopy("address");
+    onCopy("address");
   };
 
   return (
@@ -83,20 +84,20 @@ function DelegateProfile(props: DelegateProfileProps): ReactElement {
               <Tooltip
                 arrow
                 placement="top"
-                open={showToolTip.twitterHandle}
+                open={showTooltip.twitterHandle}
                 title={t`Twitter handle copied`}
               >
-                <button onClick={handleCopyTwitterHandle}>
+                <button onClick={onCopyTwitterHandle}>
                   <AnnotationIcon className="h-5 text-principalRoyalBlue" />
                 </button>
               </Tooltip>
               <Tooltip
                 arrow
                 placement="top"
-                open={showToolTip.address}
+                open={showTooltip.address}
                 title={t`Address copied`}
               >
-                <button onClick={handleCopyAddress}>
+                <button onClick={onCopyAddress}>
                   <div className="relative h-4 w-4">
                     <Image
                       layout="fill"
@@ -144,7 +145,7 @@ function DelegateProfile(props: DelegateProfileProps): ReactElement {
               <DetailedDelegateProfile
                 delegate={delegate}
                 onClose={close}
-                setDelegateAddressInput={setDelegateAddressInput}
+                onChooseDelegate={onChooseDelegate}
               />
             )}
           </Popover.Panel>

--- a/src/ui/delegate/DelegatesList/DelegatesList.tsx
+++ b/src/ui/delegate/DelegatesList/DelegatesList.tsx
@@ -32,7 +32,7 @@ function DelegatesList({
               <DelegateProfile
                 selected={selected}
                 delegate={delegate}
-                setDelegateAddressInput={setDelegateAddressInput}
+                onChooseDelegate={setDelegateAddressInput}
               />
             </li>
           );

--- a/src/ui/delegate/DelegatesList/DetailedDelegateProfile.tsx
+++ b/src/ui/delegate/DelegatesList/DetailedDelegateProfile.tsx
@@ -13,20 +13,20 @@ import { WalletJazzicon } from "src/ui/wallet/WalletJazzicon/WalletJazzicon";
 interface DetailedDelegateProfileProps {
   delegate: Delegate;
   onClose: () => void;
-  setDelegateAddressInput?: (address: string) => void;
+  onChooseDelegate?: (address: string) => void;
 }
 
 function DetailedDelegateProfile({
   delegate,
   onClose,
-  setDelegateAddressInput,
+  onChooseDelegate,
 }: DetailedDelegateProfileProps): ReactElement {
   const { account } = useWeb3React();
 
   const onClickChooseDelegate = () => {
     onClose();
-    if (setDelegateAddressInput) {
-      setDelegateAddressInput(delegate.address);
+    if (onChooseDelegate) {
+      onChooseDelegate(delegate.address);
     }
   };
 
@@ -121,7 +121,7 @@ function DetailedDelegateProfile({
 
         {/* Choose Delegate & Close Button */}
         <div className="flex flex-col gap-4 mt-auto">
-          {setDelegateAddressInput ? (
+          {onChooseDelegate ? (
             <Button
               className="w-52 flex justify-center items-center ml-auto mt-4"
               variant={ButtonVariant.GRADIENT}


### PR DESCRIPTION
Closes #235.

Things changed: 
1. Integrated HeadlessUI's popover into `DelegatesList`. Each item within the list is now a `Popover.Button` with each `DetailedDelegateProfile` being their respective `Popover.Panel`. This adds a bunch of built in accessibility features
2. Added a transition in and out for the `Popover.Panel` 
3. Cleaned up the `DelegatesList`: no longer has a `currentDelegate` state which kept track of the current delegate clicked in order to display the correct delegate within the `DetailedDelegateProfile`. This was removed in favor of each list item managing its own `Popover.Panel`