### PR TITLE
Fix length of ProgressBar in ProposalDetailsCard

### DIFF
--- a/src/ui/base/ProgressBar/ProgressBar.tsx
+++ b/src/ui/base/ProgressBar/ProgressBar.tsx
@@ -3,18 +3,35 @@ import { ReactElement } from "react";
 interface ProgressBarProps {
   // value between 0 and 1
   progress: number;
+  enableBar?: boolean;
 }
 export function ProgressBar(props: ProgressBarProps): ReactElement {
-  const { progress } = props;
+  const { progress, enableBar } = props;
 
-  const percentComplete = Math.round(progress * 100);
+  const percentComplete = Math.min(Math.floor(progress * 100), 100);
+
+  let barPosition = 0;
+  if (progress > 1) {
+    barPosition = Math.round(100 * (1 / progress));
+  }
 
   return (
-    <div className="w-full h-2 rounded-full bg-sky-300">
+    <div className="relative w-full h-2 bg-opacity-50 rounded-full bg-sky-300 ">
       <div
         style={{ width: `${percentComplete}%` }}
         className="h-full text-xs text-center text-white rounded-full bg-sky-100"
       ></div>
+      {!!barPosition && enableBar && (
+        <div
+          style={{
+            width: 3,
+            height: "200%",
+            left: `${barPosition}%`,
+            top: "-50%",
+          }}
+          className="absolute top-0 h-full border border-white rounded bg-principalRoyalBlue"
+        ></div>
+      )}
     </div>
   );
 }

--- a/src/ui/proposals/ProposalDetailsCard.tsx
+++ b/src/ui/proposals/ProposalDetailsCard.tsx
@@ -226,13 +226,13 @@ interface QuorumBarProps {
 
 function QuorumBar(props: QuorumBarProps) {
   const { votes, quorum } = props;
-  const quorumPercent = Math.round((+votes / +quorum) * 100);
+  const quorumPercent = Math.floor((+votes / +quorum) * 100);
   return (
     <div className="w-full space-y-1 text-sm text-white">
       <div>
         {votes} {t`total votes`}
       </div>
-      <ProgressBar progress={Math.max(+votes / +quorum, 1)} />
+      <ProgressBar progress={+votes / +quorum} />
       <div>
         {`${quorumPercent}%`} {t`quorum reached`}
       </div>


### PR DESCRIPTION
If more that 100% quorum was reached, then the ProgressBar went off the page.  This caps it to w-100%
Also added an optional bar to indicate how much past quorum we've reached.  Disabled for now but we can enable if design likes it.