### PR TITLE
Remove copy address button

### DIFF
--- a/src/ui/delegate/DelegatesList/DelegateProfile.tsx
+++ b/src/ui/delegate/DelegatesList/DelegateProfile.tsx
@@ -17,7 +17,7 @@ interface DelegateProfileProps {
 }
 
 function DelegateProfile(props: DelegateProfileProps): ReactElement {
-  const { selected = false, delegate } = props;
+  const { selected = false, delegate, onSelectDelegate } = props;
 
   return (
     <Popover>


### PR DESCRIPTION
Copy address button removed in favor of just using the 'Choose Delegate' button within the `DetailedDelegateProfile` popup on delegate profile click

Previous:
<img width="275" alt="Screen Shot 2022-01-12 at 11 45 35 PM" src="https://user-images.githubusercontent.com/19617238/149306060-46191bf0-1cce-4895-b399-6ba9588a1335.png">

Updated:
<img width="277" alt="Screen Shot 2022-01-12 at 11 45 59 PM" src="https://user-images.githubusercontent.com/19617238/149306059-a7b820a0-99e6-47c4-90cc-42b09398a05a.png">
