### PR TITLE
Add new disable condition to DelegateButton

### DIFF
--- a/src/ui/delegate/DelegateCard/DelegateButton.tsx
+++ b/src/ui/delegate/DelegateCard/DelegateButton.tsx
@@ -2,12 +2,14 @@ import { ReactElement } from "react";
 import Tooltip from "src/ui/base/Tooltip/Tooltip";
 import { t } from "ttag";
 import classNames from "classnames";
-
+import { Delegate } from "src/elf-council-delegates/delegates";
 import Button from "src/ui/base/Button/Button";
 import { ButtonVariant } from "src/ui/base/Button/styles";
+import CurrentDelegate from "./CurrentDelegate";
 
 interface DelegateButtonProps {
   account: string | null | undefined;
+  currentDelegate: Delegate | undefined;
   delegateAddressInput: string;
   onDelegateClick: () => void;
   invalidAddress: boolean;
@@ -19,6 +21,7 @@ interface DelegateButtonProps {
 function DelegateButton(props: DelegateButtonProps): ReactElement {
   const {
     account,
+    currentDelegate,
     delegateAddressInput,
     onDelegateClick,
     invalidAddress,
@@ -29,15 +32,25 @@ function DelegateButton(props: DelegateButtonProps): ReactElement {
 
   const noAccount = !account;
   const noInput = delegateAddressInput.length === 0;
+  const sameDelegate = currentDelegate?.address === delegateAddressInput;
 
   return (
-    <Tooltip content={getTooltipContent(noAccount, noInput, invalidAddress)}>
+    <Tooltip
+      content={getTooltipContent(
+        noAccount,
+        noInput,
+        invalidAddress,
+        sameDelegate,
+      )}
+    >
       <Button
         loading={isLoading}
         onClick={onDelegateClick}
         variant={buttonVariant}
         className={classNames("w-full", buttonClassName)}
-        disabled={noAccount || isLoading || noInput || invalidAddress}
+        disabled={
+          noAccount || isLoading || noInput || invalidAddress || sameDelegate
+        }
       >{t`Delegate`}</Button>
     </Tooltip>
   );
@@ -47,6 +60,7 @@ function getTooltipContent(
   noAccount: boolean,
   noInput: boolean,
   invalidAddress: boolean,
+  sameDelegate: boolean,
 ): string {
   if (noAccount) {
     return t`Connect wallet`;
@@ -58,6 +72,10 @@ function getTooltipContent(
 
   if (invalidAddress) {
     return t`Enter a valid address`;
+  }
+
+  if (sameDelegate) {
+    return t`Delegate already delegated to`;
   }
 
   return "";

--- a/src/ui/delegate/DelegateCard/DelegateCard.tsx
+++ b/src/ui/delegate/DelegateCard/DelegateCard.tsx
@@ -141,6 +141,7 @@ function DelegateCard(props: DelegateCardProps): ReactElement {
             <div className="flex justify-end items-end">
               <DelegateButton
                 account={account}
+                currentDelegate={currentDelegate}
                 delegateAddressInput={delegateAddressInput}
                 onDelegateClick={onDelegateClick}
                 invalidAddress={invalidAddress}


### PR DESCRIPTION
Fixed an oversight with the `DelegateButton` component. New disable button condition for the `Delegate` button--no longer able to delegate to the same address. 