### PR TITLE
Increase contrast to selected delegates

### DIFF
--- a/src/ui/delegate/DelegatesList/DelegateProfile.tsx
+++ b/src/ui/delegate/DelegatesList/DelegateProfile.tsx
@@ -54,7 +54,7 @@ function DelegateProfile(props: DelegateProfileProps): ReactElement {
               src="/assets/crown.svg"
               alt={t`Affiliated with Element Finance`}
               className={classNames({
-                "filter brightness-0 invert-[1]": selected,
+                "filter brightness-0 invert": selected,
               })}
             />
           </div>


### PR DESCRIPTION
Previous:
<img width="548" alt="Screen Shot 2022-01-14 at 12 36 20 AM" src="https://user-images.githubusercontent.com/19617238/149501964-053f5f48-0d8a-4d5b-bbbd-6ca4d1507d89.png">

Updated:
<img width="548" alt="Screen Shot 2022-01-14 at 12 34 36 AM" src="https://user-images.githubusercontent.com/19617238/149501801-d7893aa5-25e6-424d-aaa0-f26c54cd4942.png">

Could not change the fill color of the svg due to use of `next/image` `<Image />` component, opted to just use `filter brightness-0 invert-1` instead to change icon color to white
