### PR TITLE
Add useWorker and stub out a16z lib integration with comments

### DIFF
--- a/src/ui/base/useWorker.ts
+++ b/src/ui/base/useWorker.ts
@@ -7,9 +7,9 @@ const workerFunction = <Args extends unknown[]>(
   // babel converts spread arrays to a function called _toConsumableArray which
   // isn't defined in the web worker.
   // eslint-disable-next-line prefer-spread
-  const result = fn.apply(null, args);
+  const data = fn.apply(null, args);
   // eslint-disable-next-line no-restricted-globals
-  self.postMessage(result);
+  self.postMessage(data);
 };
 
 export function wrapInWorker<Args extends unknown[]>(
@@ -29,32 +29,35 @@ export function wrapInWorker<Args extends unknown[]>(
   };
 }
 
-export default function useWorker<Args extends unknown[], ReturnType>(
-  fn: (...args: Args) => ReturnType,
-): [
-  (...args: Args) => void,
-  {
-    loading: boolean;
-    result: ReturnType | undefined;
-  },
-] {
-  const [state, setState] = useState<{
-    loading: boolean;
-    result: ReturnType | undefined;
-  }>({ loading: false, result: undefined });
+interface UseWorkerResult<TCallback extends (...args: any[]) => void> {
+  run: (...args: Parameters<TCallback>) => void;
+  loading: boolean;
+  data: ReturnType<TCallback> | undefined;
+}
+
+export default function useWorker<TCallback extends (...args: any[]) => any>(
+  fn: TCallback,
+): UseWorkerResult<TCallback> {
+  const [state, setState] = useState<Omit<UseWorkerResult<TCallback>, "run">>({
+    loading: false,
+    data: undefined,
+  });
 
   const wrappedFunction = useMemo(() => wrapInWorker(fn), [fn]);
 
   const run = useCallback(
-    (...args: Args) => {
+    (...args: Parameters<TCallback>) => {
       setState((prevState) => ({ ...prevState, loading: true }));
       const worker = wrappedFunction(...args);
       worker.onmessage = ({ data }) => {
-        setState({ loading: false, result: data });
+        setState({ loading: false, data });
       };
     },
     [wrappedFunction],
   );
 
-  return [run, state];
+  return {
+    run,
+    ...state,
+  };
 }

--- a/src/ui/zkclaim/ZKClaimPage.tsx
+++ b/src/ui/zkclaim/ZKClaimPage.tsx
@@ -18,7 +18,7 @@ export default function ClaimPage(): ReactElement {
   const [publicId, setPublicId] = useState<string>();
   const [alreadyClaimed, setAlreadyClaimed] = useState(false);
   // TODO
-  // const [generateProofCallDataInWorker, { result: proofCallData, loading }] =
+  // const proofCallResult =
   //   useWorker(a16zLibrary.generateProofCallData);
   // TODO: fetch leafs from aws and generate merkletree
   // const { data: merkleTree, isLoading: merkleLeafsLoading } = useQuery({
@@ -34,7 +34,7 @@ export default function ClaimPage(): ReactElement {
   useEffect(() => {
     // TODO
     // if (data && merkleTree) {
-    //   generateProofCallDataInWorker(
+    //   proofCallResult.run(
     //     merkleTree,
     //     data.privateKey,
     //     data.secret,


### PR DESCRIPTION
- Added a new `useWorker` function which takes a function and returns `[wrappedFunction, { loading, result }]`.
  -  `wrappedFunction` - A new function that can be called to run the original function in a web worker.
  - `loading` - a Boolean indicating whether or not the web worker is currently running the function.
  - `result` - The return payload from the original function after being run in the web worker.
- Stubbed out the steps for integrating the a16z lib as comments based on conversations with Sam from a16z.