### PR TITLE
Enable external sidebar links to open on new tab 

### DIFF
--- a/src/ui/app/Sidebar.tsx
+++ b/src/ui/app/Sidebar.tsx
@@ -148,15 +148,18 @@ function SidebarLink(props: SidebarLinkProps): ReactElement {
 function SidebarLinkExternal(props: SidebarLinkExternalProps): ReactElement {
   const { link, label } = props;
   return (
-    <div className="flex justify-center items-center hover:bg-blue-50 cursor-pointer">
+    <a
+      href={link}
+      target="_blank"
+      rel="noreferrer"
+      className="w-full flex justify-center items-center hover:bg-blue-50"
+    >
       {/* Empty span w/ same width as icon to center the label text */}
       <span className="w-4" />
-      <a href={link} target="_blank" rel="noreferrer">
-        <div className="flex justify-center p-3 cursor-pointer text-brandDarkBlue-dark">
-          <p>{label}</p>
-        </div>
-      </a>
+      <div className="flex justify-center p-3 cursor-pointer text-brandDarkBlue-dark">
+        <p>{label}</p>
+      </div>
       <ExternalLinkIcon className="w-4 h-4 text-principalRoyalBlue" />
-    </div>
+    </a>
   );
 }


### PR DESCRIPTION
External sidebar links now open to new tabs and also added an external svg icon to each external link

<img width="242" alt="Screen Shot 2022-02-01 at 7 38 55 PM" src="https://user-images.githubusercontent.com/19617238/152089566-e545ee13-5577-466d-810b-a8a97c73a00e.png">

