### PR TITLE
Fix self-delegate button on airdrop

### DIFF
--- a/src/ui/airdrop/ChooseDelegate/ChooseDelegate.tsx
+++ b/src/ui/airdrop/ChooseDelegate/ChooseDelegate.tsx
@@ -83,7 +83,7 @@ export function ChooseDelegate({
 
     // Somewhat of a hack to clear all other selections when the
     // user self-delegates
-    const indexOfAccountInDelegatesList = delegates.findIndex(
+    const indexOfAccountInDelegatesList = shuffledDelegates.findIndex(
       ({ address }) => address === account,
     );
     setSelectedDelegateIndex(
@@ -92,7 +92,7 @@ export function ChooseDelegate({
         : indexOfAccountInDelegatesList,
     );
     setCustomDelegateAddress("");
-  }, [account]);
+  }, [account, shuffledDelegates]);
 
   const handleCustomDelegateInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>): void => {


### PR DESCRIPTION
Self delegate button on Airdrop Page not working correctly after shuffling delegates as the function was still cycling through the original list of delegates via the `.findIndex()` function. Replaced `delegates` -> `shuffledDelegates`