### PR TITLE
[overview] Add etherscan link 

### DIFF
--- a/src/elf-etherscan/domain.ts
+++ b/src/elf-etherscan/domain.ts
@@ -13,6 +13,10 @@ function getDomain() {
   return "https://etherscan.io";
 }
 
+export function getEtherscanAddress(account: string): string {
+  return `${ETHERSCAN_DOMAIN}/address/${account}`;
+}
+
 export const ETHERSCAN_TRANSACTION_DOMAIN =
   addressesJson.chainId === ChainId.LOCAL
     ? `${ETHERSCAN_DOMAIN}/transaction`

--- a/src/ui/overview/PortfolioCard.tsx
+++ b/src/ui/overview/PortfolioCard.tsx
@@ -12,6 +12,7 @@ import Card, { CardVariant } from "src/ui/base/Card/Card";
 import { useDeposited } from "src/ui/base/lockingVault/useDeposited";
 import { RESOURCES_URL } from "src/ui/resources";
 import { useVotingPowerForAccount } from "src/ui/voting/useVotingPowerForAccount";
+import { getEtherscanAddress } from "src/elf-etherscan/domain";
 
 const votingBalanceTooltipText = t`Don't know what your voting balance is?  Click on the icon to find out more.`;
 const votingPowerTooltipText = t`Don't know what your voting power is?  Click on the icon to find out more.`;
@@ -37,9 +38,16 @@ export function PortfolioCard(props: PortfolioCardProps): ReactElement {
     >
       <div>
         <span className="text-xl font-bold tracking-widest text-white">{t`Portfolio`}</span>
-        <span className="ml-2 text-sm font-light tracking-widest text-white">
-          {account && `(${formatWalletAddress(account)})`}
-        </span>
+        {account && (
+          <a
+            href={getEtherscanAddress(account)}
+            target="_blank"
+            rel="noreferrer"
+            className="ml-2 text-sm font-light tracking-widest text-white underline hover:no-underline"
+          >
+            ({formatWalletAddress(account)})
+          </a>
+        )}
       </div>
       <div className="flex flex-col min-h-full mb-8 align-bottom">
         <BalanceWithLabel


### PR DESCRIPTION
The user's address displayed in the Portfolio card now links to etherscan (opens in a new tab):

<img width="522" alt="image" src="https://user-images.githubusercontent.com/4524175/152621486-fc3a8b20-c6f2-43a4-b74f-6b7b43667d13.png">
