### PR TITLE
Change voting power to ELFI

### DIFF
--- a/src/ui/overview/SummaryCards.tsx
+++ b/src/ui/overview/SummaryCards.tsx
@@ -52,8 +52,8 @@ export function SummaryCards({
         tooltipContent={t`Number of unique delegates with voting power in the system`}
       />
       <SummaryCard
-        title={t`Circulating Voting Power`}
-        balance={`${formattedTotalVotingPower} ELFI`}
+        title={t`Circulating ELFI`}
+        balance={`${formattedTotalVotingPower}`}
         tooltipContent={t`The total amount of voting power in the system`}
       />
     </div>


### PR DESCRIPTION
Changing the top card to be consistent with how we display ELFI in the portfolio card:
![image](https://user-images.githubusercontent.com/3289505/153658877-307b21eb-98f3-4f85-b6f4-95b46a123cd5.png)

The portfolio card for reference:
![image](https://user-images.githubusercontent.com/3289505/153658959-f97bf243-88a4-483b-8a36-9638cad90b39.png)
