### PR TITLE
Fix sidebar ui bug & update to match new designs

### DIFF
--- a/src/ui/app/Sidebar.tsx
+++ b/src/ui/app/Sidebar.tsx
@@ -149,14 +149,14 @@ function SidebarLink(props: SidebarLinkProps): ReactElement {
   const isActive = router.pathname === link;
 
   return (
-    <div className="flex justify-center hover:bg-blue-50">
+    <div className="flex justify-center">
       <Link href={link}>
         {/* There's a big discussion about how awful the Link api is for a11y
       here: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/402 the
       best thing to do for now is just ignore this rule when an anchor tag is
       the child of a Link since all a tags *should* have an href 🙁 */
         /* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-        <a className="flex items-center md:w-1/2">
+        <a className="flex items-center px-2 hover:bg-blue-50 md:w-[55%]">
           {icon}
           <div
             className={classNames(
@@ -175,12 +175,12 @@ function SidebarLink(props: SidebarLinkProps): ReactElement {
 function SidebarLinkExternal(props: SidebarLinkExternalProps): ReactElement {
   const { link, label } = props;
   return (
-    <div className="flex justify-center hover:bg-blue-50">
+    <div className="flex justify-center ">
       <a
         href={link}
         target="_blank"
         rel="noreferrer"
-        className="flex items-center md:w-1/2"
+        className="flex items-center px-2  hover:bg-blue-50 md:w-[55%]"
       >
         <ExternalLinkIcon className="h-4 w-4 text-principalRoyalBlue" />
         <div className="flex cursor-pointer justify-center p-3 text-brandDarkBlue-dark">


### PR DESCRIPTION
Current:
<img width="238" alt="Screen Shot 2022-02-15 at 2 56 58 PM" src="https://user-images.githubusercontent.com/19617238/154164586-d05d970e-5f1a-407c-82f7-c48044ea87a4.png">

Mock:
![image](https://user-images.githubusercontent.com/19617238/154164955-1982fc21-11c7-4fa9-a264-ad3243b21153.png)

Proposed:
<img width="235" alt="Screen Shot 2022-02-15 at 3 01 13 PM" src="https://user-images.githubusercontent.com/19617238/154164583-00e72657-f16e-4817-b928-6c2cea252f6f.png">
