### PR TITLE
Update latest proposals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12745,7 +12745,7 @@
       }
     },
     "elf-council-proposals": {
-      "version": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-proposals.git#b6938ad6b69435296327c86fd17d2c8cb955a1de",
+      "version": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-proposals.git#28ae9450137f9dc693cc44f3f4d1a5ebed486559",
       "from": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-proposals.git",
       "requires": {
         "@types/lodash.uniq": "^4.5.6",
@@ -12756,24 +12756,6 @@
         "lodash.zip": "^4.2.0",
         "tsc": "^2.0.3",
         "tsconfig-paths": "^3.10.1"
-      },
-      "dependencies": {
-        "elf-council-tokenlist": {
-          "version": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-tokenlist.git#2fe7bdaf5183b3b26adcad72cedf68fd21e8efdc",
-          "from": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-tokenlist.git",
-          "requires": {
-            "@ethersproject/providers": "^5.4.0",
-            "@uniswap/token-lists": "^1.0.0-beta.26",
-            "elf-council-typechain": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-typechain.git"
-          }
-        },
-        "elf-council-typechain": {
-          "version": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-typechain.git#b7c5095bf48d3d56123a3f42656659b370bfa48e",
-          "from": "git+https://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:x-oauth-basic@github.com/element-fi/elf-council-typechain.git",
-          "requires": {
-            "tsc": "^2.0.3"
-          }
-        }
       }
     },
     "elf-council-tokenlist": {


### PR DESCRIPTION
We get this data from s3 now, but this keeps us up to date with the latest commit in the elf-council-proposals repo