### PR TITLE
`useWorker` refactor

### DIFF
--- a/src/ui/base/useWorker.ts
+++ b/src/ui/base/useWorker.ts
@@ -42,7 +42,9 @@ interface UseWorkerResult<TCallback extends Callback> {
   hasRun: boolean;
   loading: boolean;
   data?: Awaited<ReturnType<TCallback>>;
+  // Defined when an error event occurs in the worker
   error?: ErrorEvent;
+  // Defined when the worker receives a message that can't be deserialized.
   messageError?: MessageEvent;
 }
 


### PR DESCRIPTION
- Refactored types
- Made promises automatically resolve
- Added error and hasRun props
- Added another simpler hook which returns a function that returns a promise which resolves with the value posted from the worker.
- Modified the wrappedFunction to send args to the worker function in a posted msg rather than including them in the blob string to avoid issues with serializing some types (e.g. BigInt).