### PR TITLE
Add status label to proposal details card

### DIFF
--- a/src/ui/proposals/ProposalDetailsCard.tsx
+++ b/src/ui/proposals/ProposalDetailsCard.tsx
@@ -182,12 +182,12 @@ export function ProposalDetailsCard(
           {t`Proposal ${proposalId}`}
         </h1>
         <div className="flex w-full justify-between">
-          <div className="flex-1 shrink-0 text-ellipsis font-light text-white">
+          <div className="flex-1 shrink-0 text-ellipsis font-light text-white lg:mt-2">
             {snapshotProposal?.title}
           </div>
-          <div className="lg:-mt-6">
+          <div className="h-min rounded-md bg-white py-1 px-2 lg:-mt-8">
             {proposalStatus && (
-              <div className="flex w-full items-center justify-end space-x-2 text-white">
+              <div className="flex w-full items-center justify-end space-x-2 text-black">
                 <div>{ProposalStatusLabels[proposalStatus]}</div>
                 <ProposalStatusIcon signer={signer} proposal={proposal} />
               </div>


### PR DESCRIPTION
Instead of changing the dot to a different color, I opted to just turn that into a label with a white bg as the component is reused elsewhere on a white background and so that wouldn't work out without changing up the entire color scheme.

Issue:
![image](https://user-images.githubusercontent.com/19617238/157125374-0c18364f-8e0b-4ebf-b8ae-f881da1966d2.png)

Proposed Fix:
![Screen Shot 2022-03-07 at 2 03 43 PM](https://user-images.githubusercontent.com/19617238/157125507-3688f98e-bc4c-4c10-9157-5b2cac25acc6.png)

