### PR TITLE
Fix proposal details display bug

### DIFF
--- a/src/ui/proposals/ProposalsPage.tsx
+++ b/src/ui/proposals/ProposalsPage.tsx
@@ -56,12 +56,12 @@ export default function ProposalsPage({
     currentBlockNumber,
   );
 
-  const setDefaultActiveProposals = useCallback(() => {
+  const setDefaultActiveProposal = useCallback(() => {
     setSelectedProposalId(activeProposals?.[0]?.proposalId);
     setSelectedProposal(activeProposals?.[0]);
   }, [activeProposals]);
 
-  const setDefaultPastProposals = useCallback(() => {
+  const setDefaultPastProposal = useCallback(() => {
     setSelectedProposalId(pastProposals?.[0]?.proposalId);
     setSelectedProposal(pastProposals?.[0]);
   }, [pastProposals]);
@@ -95,7 +95,7 @@ export default function ProposalsPage({
         setSelectedProposalId(undefined);
         setSelectedProposal(undefined);
       } else {
-        setDefaultActiveProposals();
+        setDefaultActiveProposal();
       }
     }
   };
@@ -109,7 +109,7 @@ export default function ProposalsPage({
       } else {
         // select the first proposal when the user clicks to view the
         // past tab
-        setDefaultPastProposals();
+        setDefaultPastProposal();
       }
     }
   };
@@ -117,9 +117,9 @@ export default function ProposalsPage({
   useEffect(() => {
     if (isTailwindLargeScreen && !selectedProposal) {
       if (activeTabId === "past") {
-        setDefaultPastProposals();
+        setDefaultPastProposal();
       } else {
-        setDefaultActiveProposals();
+        setDefaultActiveProposal();
       }
     }
   }, [
@@ -127,8 +127,8 @@ export default function ProposalsPage({
     isTailwindLargeScreen,
     pastProposals,
     selectedProposal,
-    setDefaultActiveProposals,
-    setDefaultPastProposals,
+    setDefaultActiveProposal,
+    setDefaultPastProposal,
   ]);
 
   return (


### PR DESCRIPTION
Fixed this bug:
<video width="171" alt="Screen Shot 2022-03-11 at 4 17 16 PM" src="https://user-images.githubusercontent.com/19617238/158235120-9b4e4b4e-027c-4bc8-8369-f04e73832818.mp4
">


It now opens to the default first proposal for either the `active` or `past` tabs when expanding to a larger screen size if the proposal details full-screen view was closed in the small-medium view
