### PR TITLE
Change tooltip text

### DIFF
--- a/src/ui/app/Header.tsx
+++ b/src/ui/app/Header.tsx
@@ -12,7 +12,7 @@ import {
   IconSize,
 } from "src/ui/base/ElementIconCircle/ElementIconCircle";
 import Tooltip from "src/ui/base/Tooltip/Tooltip";
-import TooltipDefinitions from "src/ui/voting/tooltipDefinitions";
+import { TooltipDefinition } from "src/ui/voting/tooltipDefinitions";
 import { Provider } from "@ethersproject/providers";
 
 const GAS_URL = "https://www.etherchain.org/tools/gasnow";
@@ -50,7 +50,7 @@ function Header(): ReactElement {
                 {gasPrice?.recommendedBaseFee || 0.0}
               </span>
             </a>
-            <Tooltip content={t`${TooltipDefinitions.OWNED_ELFI}`}>
+            <Tooltip content={t`${TooltipDefinition.OWNED_ELFI}`}>
               <span className="mr-8 flex items-center gap-2 font-bold text-principalRoyalBlue">
                 <ElementIconCircle size={IconSize.MEDIUM} />
                 <span>

--- a/src/ui/overview/PortfolioCard.tsx
+++ b/src/ui/overview/PortfolioCard.tsx
@@ -6,7 +6,7 @@ import { useMerkleInfo } from "src/elf/merkle/useMerkleInfo";
 import { formatWalletAddress } from "src/formatWalletAddress";
 import { useUnclaimedAirdrop } from "src/ui/airdrop/useUnclaimedAirdrop";
 import { BalanceWithLabel } from "src/ui/base/BalanceWithLabel/BalanceWithLabel";
-import TooltipDefinitions from "src/ui/voting/tooltipDefinitions";
+import { TooltipDefinition } from "src/ui/voting/tooltipDefinitions";
 import LinkButton from "src/ui/base/Button/LinkButton";
 import { ButtonVariant } from "src/ui/base/Button/styles";
 import Card, { CardVariant } from "src/ui/base/Card/Card";
@@ -50,13 +50,13 @@ export function PortfolioCard(props: PortfolioCardProps): ReactElement {
         <BalanceWithLabel
           className="mt-8 w-full"
           balance={amountDeposited}
-          tooltipText={t`${TooltipDefinitions.OWNED_ELFI}`}
+          tooltipText={t`${TooltipDefinition.OWNED_ELFI}`}
           label={t`ELFI`}
         />
         <BalanceWithLabel
           className="mt-8 w-full"
           balance={votingPower}
-          tooltipText={t`${TooltipDefinitions.OWNED_VOTING_POWER}`}
+          tooltipText={t`${TooltipDefinition.OWNED_VOTING_POWER}`}
           label={t`Your Voting Power`}
         />
         {!!Number(unclaimedAirdrop) && (

--- a/src/ui/proposals/ProposalDetailsCard.tsx
+++ b/src/ui/proposals/ProposalDetailsCard.tsx
@@ -29,7 +29,7 @@ import { getIsVotingOpen } from "src/elf-council-proposals";
 import { ETHERSCAN_TRANSACTION_DOMAIN } from "src/elf-etherscan/domain";
 import { VotingPower } from "src/elf/proposals/VotingPower";
 import { BalanceWithLabel } from "src/ui/base/BalanceWithLabel/BalanceWithLabel";
-import TooltipDefinitions from "./tooltipDefinitions";
+import { TooltipDefinition } from "./tooltipDefinitions";
 import Button from "src/ui/base/Button/Button";
 import { ButtonVariant } from "src/ui/base/Button/styles";
 import GradientCard from "src/ui/base/Card/GradientCard";
@@ -296,7 +296,7 @@ export function ProposalDetailsCard(
               <BalanceWithLabel
                 className="mt-4 w-full"
                 balance={accountVotingPower}
-                tooltipText={t`${TooltipDefinitions.OWNED_PROPOSAL_VOTING_POWER}`}
+                tooltipText={t`${TooltipDefinition.OWNED_PROPOSAL_VOTING_POWER}`}
                 label={t`Voting Power`}
               />
 

--- a/src/ui/proposals/tooltipDefinitions.ts
+++ b/src/ui/proposals/tooltipDefinitions.ts
@@ -1,5 +1,3 @@
-enum TooltipDefinitions {
+export enum TooltipDefinition {
   OWNED_PROPOSAL_VOTING_POWER = "The voting power allocated to you for this proposal.",
 }
-
-export default TooltipDefinitions;

--- a/src/ui/voting/tooltipDefinitions.ts
+++ b/src/ui/voting/tooltipDefinitions.ts
@@ -1,6 +1,4 @@
-enum TooltipDefinitions {
+export enum TooltipDefinition {
   OWNED_ELFI = "The amount of ELFI you own in the system. Your ELFI can be delegated to give someone voting power, where 1 ELFI = +1 Voting Power.",
   OWNED_VOTING_POWER = "All voting power allocated to you from voting vaults and delegated ELFI.",
 }
-
-export default TooltipDefinitions;


### PR DESCRIPTION
A small copy change that was proposed in our internal frontend discord channel: 

Tooltip for Elfi and Voting Power should be changed to… 
1. ELFI - `The amount of voting power you own in the system` -> `The amount of ELFI you own`
2. Voting Power - `The sum of all voting power delegated to you` -> `The amount of voting power you have in Element Council`