### PR TITLE
Add address screening

### DIFF
--- a/src/ui/router/useRouterSteps.ts
+++ b/src/ui/router/useRouterSteps.ts
@@ -48,6 +48,10 @@ export default function useRouterSteps<Step = number>(
   const { pathname, push, replace } = useRouter();
   const { [paramName]: paramStep } = useParams();
 
+  // use these methods in dependency arrays
+  const staticRouterMethods = useRef({ safePush: push, safeReplace: replace });
+  const { safePush, safeReplace } = staticRouterMethods.current;
+
   const [completedSteps, setCompletedSteps] = useState(initialCompleted);
 
   const currentStep = useMemo(() => {
@@ -120,9 +124,9 @@ export default function useRouterSteps<Step = number>(
   const goToStep = useCallback(
     (step: number | Step) => {
       completeStep(getStepNumber(step) - 1);
-      push(getStepPath(step));
+      safePush(getStepPath(step));
     },
-    [push, getStepPath, completeStep, getStepNumber],
+    [safePush, getStepPath, completeStep, getStepNumber],
   );
 
   const goToPreviousStep = useCallback(() => {
@@ -136,13 +140,15 @@ export default function useRouterSteps<Step = number>(
   useEffect(() => {
     if (!canViewStep(currentStep)) {
       // TODO: error notification?
-      replace(getStepPath(completedSteps + 1), undefined, { shallow: true });
+      safeReplace(getStepPath(completedSteps + 1), undefined, {
+        shallow: true,
+      });
     }
   }, [
     paramStep,
     canViewStep,
     currentStep,
-    replace,
+    safeReplace,
     getStepPath,
     completedSteps,
   ]);

--- a/src/ui/zkclaim/NoPassCard.tsx
+++ b/src/ui/zkclaim/NoPassCard.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement } from "react";
+import Button from "src/ui/base/Button/Button";
+import Card, { CardVariant } from "src/ui/base/Card/Card";
+import { t } from "ttag";
+import { ButtonVariant } from "src/ui/base/Button/styles";
+import H2 from "src/ui/base/H2/H2";
+
+interface NoPassCardProps {
+  className?: string;
+  onPreviousStep?: () => void;
+}
+
+export default function NoPassCard({
+  className,
+  onPreviousStep,
+}: NoPassCardProps): ReactElement {
+  return (
+    <Card className={className} variant={CardVariant.BLUE}>
+      <div className="flex flex-col justify-center gap-2 px-6 pt-6 pb-4 text-white sm:items-center sm:px-20 sm:pt-20 sm:pb-14 sm:text-center">
+        <h1 className="mb-5 text-3xl font-semibold">{t`Public ID not eligible`}</h1>
+        <H2 className="mb-12 text-2xl text-goldYellow sm:mb-24">{t`This account is not eligible for the airdrop`}</H2>
+        <Button
+          variant={ButtonVariant.WHITE}
+          onClick={onPreviousStep}
+        >{t`Back`}</Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/ui/zkclaim/useAddressScreening.ts
+++ b/src/ui/zkclaim/useAddressScreening.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "react-query";
+
+interface APIResponse {
+  status: number;
+  data: boolean | null;
+  error: string | null;
+}
+
+interface UseAddressScreening {
+  pass: boolean | null | undefined;
+  error: unknown;
+}
+
+export default function useAddressScreening(
+  address: string | null | undefined,
+): UseAddressScreening {
+  const { data: result, error } = useQuery<APIResponse>({
+    queryKey: ["address-screen", address],
+    queryFn: () =>
+      fetch("https://6zqnxzsgja.execute-api.us-east-2.amazonaws.com/screen", {
+        method: "POST",
+        body: JSON.stringify({ address: address }),
+      }).then((res) => res.json()),
+    staleTime: Infinity,
+    enabled: !!address,
+  });
+  return {
+    pass: result?.data || undefined,
+    error: result?.error || error,
+  };
+}


### PR DESCRIPTION
- Added a new `useAddressScreening` hook to screen addresses through TRM
- Added a new `NoPassCard` to the ZK claim flow
- Added an effect to jump to the `NoPassCard` if the screen comes back false
- Wrapped a few router methods in a `useRef` for `useRouterSteps` to fix rerendering issues. The `push` and `replace` methods were being redefined on each render.

![image](https://user-images.githubusercontent.com/3289505/158288786-25764629-1297-4996-9bb5-54244a4cc8cc.png)
