### PR TITLE
Fix buttons to match auto-next-step behavior

### DIFF
--- a/src/ui/airdrop/AirdropPage/AirdropPage.tsx
+++ b/src/ui/airdrop/AirdropPage/AirdropPage.tsx
@@ -173,11 +173,7 @@ export default function AirdropPage(): ReactElement {
 
             case Step.AIRDROP_PREVIEW:
               return (
-                <AirdropPreview
-                  account={account}
-                  onPrevStep={goToPreviousStep}
-                  onNextStep={goToNextStep}
-                />
+                <AirdropPreview account={account} onNextStep={goToNextStep} />
               );
 
             case Step.DELEGATE_INSTRUCTIONS:

--- a/src/ui/airdrop/AirdropPreview/AirdropPreview.tsx
+++ b/src/ui/airdrop/AirdropPreview/AirdropPreview.tsx
@@ -16,7 +16,7 @@ import { jt, t } from "ttag";
 interface AirdropPreviewProps {
   account: string | null | undefined;
   onNextStep: () => void;
-  onPrevStep: () => void;
+  onPrevStep?: () => void;
 }
 
 const elementIcon = (

--- a/src/ui/airdrop/StartAirdropCard/StartAirdropCard.tsx
+++ b/src/ui/airdrop/StartAirdropCard/StartAirdropCard.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "@ethersproject/providers";
 import React, { ReactElement } from "react";
-import Button from "src/ui/base/Button/Button";
 import { ButtonVariant } from "src/ui/base/Button/styles";
 import Card, { CardVariant } from "src/ui/base/Card/Card";
 import useOnConnected from "src/ui/wallet/useOnConnected";
@@ -8,10 +7,7 @@ import {
   ElementIconCircle,
   IconSize,
 } from "src/ui/base/ElementIconCircle/ElementIconCircle";
-import {
-  ConnectWalletButton,
-  WalletProfileButton,
-} from "src/ui/wallet/ConnectWalletButton";
+import { ConnectWalletButton } from "src/ui/wallet/ConnectWalletButton";
 import { jt, t } from "ttag";
 
 interface StartAirdropCardProps {
@@ -26,9 +22,6 @@ const elementIcon = (
 );
 
 export function StartAirdropCard({
-  walletConnectionActive,
-  account,
-  library,
   onNextStep,
 }: StartAirdropCardProps): ReactElement {
   useOnConnected(onNextStep);
@@ -37,21 +30,7 @@ export function StartAirdropCard({
       variant={CardVariant.BLUE}
       className="flex h-full min-h-full w-full flex-col text-center text-white"
     >
-      <div className="flex justify-end p-2">
-        {!account ? (
-          <ConnectWalletButton
-            label={t`Connect wallet`}
-            variant={ButtonVariant.GRADIENT}
-          />
-        ) : (
-          <WalletProfileButton
-            provider={library}
-            variant={ButtonVariant.PRIMARY}
-            account={account}
-            walletConnectionActive={walletConnectionActive}
-          />
-        )}
-      </div>
+      <div className="flex justify-end p-2"></div>
       <div className="flex h-full flex-col items-center justify-center space-y-5 p-12">
         <div className="flex w-full flex-col items-center justify-center space-y-8 md:w-7/12">
           <span className="flex items-center text-center text-base font-semibold tracking-wider">{jt`Introducing ${elementIcon} ELFI`}</span>
@@ -70,11 +49,10 @@ export function StartAirdropCard({
         </div>
 
         <div className="flex w-full justify-center space-x-4 pt-12">
-          <Button
-            disabled={!account}
+          <ConnectWalletButton
+            label={t`Connect wallet`}
             variant={ButtonVariant.GRADIENT}
-            onClick={onNextStep}
-          >{t`Check for airdrop`}</Button>
+          />
         </div>
       </div>
     </Card>

--- a/src/ui/airdrop/StepCard/StepCard.tsx
+++ b/src/ui/airdrop/StepCard/StepCard.tsx
@@ -10,7 +10,7 @@ interface StepCardProps {
   nextStepDisabled?: boolean;
   nextStepLabel?: string | ReactNode;
   prevStepLabel?: string;
-  onPrevStep: () => void;
+  onPrevStep?: () => void;
   children?: ReactNode;
   className?: string;
 }
@@ -33,10 +33,13 @@ export function StepCard({
       <div className="flex h-full flex-col justify-between p-2">
         {children}
         <div className="flex justify-between pt-6">
-          <Button onClick={onPrevStep} variant={ButtonVariant.WHITE}>
-            <span className="px-10">{prevStepLabel}</span>
-          </Button>
+          {onPrevStep && (
+            <Button onClick={onPrevStep} variant={ButtonVariant.WHITE}>
+              <span className="px-10">{prevStepLabel}</span>
+            </Button>
+          )}
           <Button
+            className="ml-auto"
             disabled={nextStepDisabled}
             onClick={onNextStep}
             variant={ButtonVariant.GRADIENT}


### PR DESCRIPTION
- Replaced the unclickable "Check for airdrop" button on intro card with a connect wallet button.
- Removed old connect wallet button in the top right of the card.
- Made `onPrevStep` optional and removed it on the Preview step.

![image](https://user-images.githubusercontent.com/3289505/160910566-f5a4e930-a6de-409f-9134-258c840e3a9a.png)

![image](https://user-images.githubusercontent.com/3289505/160910606-1939b97f-bf45-451f-8314-2404703a83b7.png)
