### PR TITLE
Integrate zk contract

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,13 @@
 {
   "cSpell.words": [
+    "commify",
     "defi",
     "ELFI",
     "ELFIverse",
     "headlessui",
     "heroicons",
+    "Jazzicon",
+    "pedersen",
     "semibold",
     "ttag"
   ]

--- a/src/elf/contracts.ts
+++ b/src/elf/contracts.ts
@@ -40,38 +40,51 @@ export const airdropContract = Airdrop__factory.connect(
   defaultProvider,
 );
 
+// TODO: Update addressesJson
 export const githubTier1PrivateAirdropContract =
   PrivateAirdrop__factory.connect(
-    "0x7198A8379fE0A0663A1E7020F6100F39b53bbB9e",
+    process.env.NEXT_PUBLIC_CHAIN_NAME === "goerli"
+      ? "0x7198A8379fE0A0663A1E7020F6100F39b53bbB9e"
+      : "0x5ae69B714859A3C15281e0a227D9B8C82F03b966",
     defaultProvider,
   );
 
 export const githubTier2PrivateAirdropContract =
   PrivateAirdrop__factory.connect(
-    "0xd21A03818ffe26dD92AEeD030E8a4b920c25C1cd",
+    process.env.NEXT_PUBLIC_CHAIN_NAME === "goerli"
+      ? "0xd21A03818ffe26dD92AEeD030E8a4b920c25C1cd"
+      : "0x63A2548f0a3795a35Ff62121E5f8C24Ada9831F8",
     defaultProvider,
   );
 
 export const githubTier3PrivateAirdropContract =
   PrivateAirdrop__factory.connect(
-    "0xd98BD503c766F2ee0Bf05A4f34dA50af5B71D051",
+    process.env.NEXT_PUBLIC_CHAIN_NAME === "goerli"
+      ? "0xd98BD503c766F2ee0Bf05A4f34dA50af5B71D051"
+      : "0x72D3acDAd21dF959DB2C112A0a5982d03759a154",
     defaultProvider,
   );
 
 export const discordTier1PrivateAirdropContract =
   PrivateAirdrop__factory.connect(
-    "0x8c7a3457742bC7ae91Bec25ea9Ab5dCbEF412292",
+    process.env.NEXT_PUBLIC_CHAIN_NAME === "goerli"
+      ? "0x8c7a3457742bC7ae91Bec25ea9Ab5dCbEF412292"
+      : "0x508071cEEf3d24D94b6783c0808fe1A417DDa485",
     defaultProvider,
   );
 
 export const discordTier2PrivateAirdropContract =
   PrivateAirdrop__factory.connect(
-    "0x6E023DAF6D9B89491A86A4554651fBaF3b8402FE",
+    process.env.NEXT_PUBLIC_CHAIN_NAME === "goerli"
+      ? "0x6E023DAF6D9B89491A86A4554651fBaF3b8402FE"
+      : "0x805bb52e4D9795B44C1ecd191Bd31F1D4a9C2dA5",
     defaultProvider,
   );
 
 export const discordTier3PrivateAirdropContract =
   PrivateAirdrop__factory.connect(
-    "0x6923F46Bfbf87E01428b8a70B1B6737a982ABcdA",
+    process.env.NEXT_PUBLIC_CHAIN_NAME === "goerli"
+      ? "0x6923F46Bfbf87E01428b8a70B1B6737a982ABcdA"
+      : "0xb7726ee8d589fd3e74C0369aB8F08D5d847bC86A",
     defaultProvider,
   );

--- a/src/elf/contracts.ts
+++ b/src/elf/contracts.ts
@@ -1,5 +1,6 @@
 import {
   Airdrop__factory,
+  PrivateAirdrop__factory,
   CoreVoting__factory,
   ERC20Permit__factory,
   LockingVault__factory,
@@ -36,5 +37,10 @@ export const vestingContract = VestingVault__factory.connect(
 
 export const airdropContract = Airdrop__factory.connect(
   addressesJson.addresses.airdrop,
+  defaultProvider,
+);
+
+export const privateAirdropContract = PrivateAirdrop__factory.connect(
+  "",
   defaultProvider,
 );

--- a/src/elf/contracts.ts
+++ b/src/elf/contracts.ts
@@ -40,7 +40,38 @@ export const airdropContract = Airdrop__factory.connect(
   defaultProvider,
 );
 
-export const privateAirdropContract = PrivateAirdrop__factory.connect(
-  "",
-  defaultProvider,
-);
+export const githubTier1PrivateAirdropContract =
+  PrivateAirdrop__factory.connect(
+    "0x7198A8379fE0A0663A1E7020F6100F39b53bbB9e",
+    defaultProvider,
+  );
+
+export const githubTier2PrivateAirdropContract =
+  PrivateAirdrop__factory.connect(
+    "0xd21A03818ffe26dD92AEeD030E8a4b920c25C1cd",
+    defaultProvider,
+  );
+
+export const githubTier3PrivateAirdropContract =
+  PrivateAirdrop__factory.connect(
+    "0xd98BD503c766F2ee0Bf05A4f34dA50af5B71D051",
+    defaultProvider,
+  );
+
+export const discordTier1PrivateAirdropContract =
+  PrivateAirdrop__factory.connect(
+    "0x8c7a3457742bC7ae91Bec25ea9Ab5dCbEF412292",
+    defaultProvider,
+  );
+
+export const discordTier2PrivateAirdropContract =
+  PrivateAirdrop__factory.connect(
+    "0x6E023DAF6D9B89491A86A4554651fBaF3b8402FE",
+    defaultProvider,
+  );
+
+export const discordTier3PrivateAirdropContract =
+  PrivateAirdrop__factory.connect(
+    "0x6923F46Bfbf87E01428b8a70B1B6737a982ABcdA",
+    defaultProvider,
+  );

--- a/src/ui/zkclaim/AlreadyClaimedCard.tsx
+++ b/src/ui/zkclaim/AlreadyClaimedCard.tsx
@@ -3,20 +3,23 @@ import Card, { CardVariant } from "src/ui/base/Card/Card";
 import H2 from "src/ui/base/H2/H2";
 import ClaimAmountCard from "./ClaimAmountCard";
 import { t } from "ttag";
+import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
 
 interface AlreadyClaimedCardProps {
   className?: string;
+  contract: PrivateAirdrop | undefined;
 }
 
 export default function AlreadyClaimedCard({
   className,
+  contract,
 }: AlreadyClaimedCardProps): ReactElement {
   return (
     <Card className={className} variant={CardVariant.BLUE}>
       <div className="flex flex-col justify-center gap-2 px-8 pt-2 pb-4 text-white sm:items-center sm:px-16 sm:pt-6 sm:pb-14 sm:text-center md:px-32">
         <h1 className="mb-5 text-3xl font-semibold">{t`Congratulations!`}</h1>
         <H2 className="mb-9 text-2xl text-votingGreen">{t`You've already claimed your $ELFI.`}</H2>
-        <ClaimAmountCard label={t`Claimed voting power`} />
+        <ClaimAmountCard label={t`Claimed voting power`} contract={contract} />
       </div>
     </Card>
   );

--- a/src/ui/zkclaim/AlreadyClaimedCard.tsx
+++ b/src/ui/zkclaim/AlreadyClaimedCard.tsx
@@ -8,9 +8,6 @@ interface AlreadyClaimedCardProps {
   className?: string;
 }
 
-// PLACEHOLDER
-const ELFI_TOKEN_AMOUNT = "10000.0";
-
 export default function AlreadyClaimedCard({
   className,
 }: AlreadyClaimedCardProps): ReactElement {
@@ -19,10 +16,7 @@ export default function AlreadyClaimedCard({
       <div className="flex flex-col justify-center gap-2 px-8 pt-2 pb-4 text-white sm:items-center sm:px-16 sm:pt-6 sm:pb-14 sm:text-center md:px-32">
         <h1 className="mb-5 text-3xl font-semibold">{t`Congratulations!`}</h1>
         <H2 className="mb-9 text-2xl text-votingGreen">{t`You've already claimed your $ELFI.`}</H2>
-        <ClaimAmountCard
-          amount={ELFI_TOKEN_AMOUNT}
-          label={t`Claimed voting power`}
-        />
+        <ClaimAmountCard label={t`Claimed voting power`} />
       </div>
     </Card>
   );

--- a/src/ui/zkclaim/ClaimAmountCard.tsx
+++ b/src/ui/zkclaim/ClaimAmountCard.tsx
@@ -7,17 +7,20 @@ import {
   IconSize,
 } from "src/ui/base/ElementIconCircle/ElementIconCircle";
 import useClaimableAmount from "./useClaimableAmount";
+import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
 
 interface ClaimAmountCardProps {
   label?: string;
   className?: string;
+  contract: PrivateAirdrop | undefined;
 }
 
 export default function ClaimAmountCard({
   label = t`Claimable voting power`,
   className,
+  contract,
 }: ClaimAmountCardProps): ReactElement {
-  const claimableAmount = useClaimableAmount();
+  const claimableAmount = useClaimableAmount(contract);
   return (
     <div
       className={classNames(

--- a/src/ui/zkclaim/ClaimAmountCard.tsx
+++ b/src/ui/zkclaim/ClaimAmountCard.tsx
@@ -1,23 +1,23 @@
 import { ReactElement } from "react";
+import { commify } from "ethers/lib/utils";
+import { t } from "ttag";
+import classNames from "classnames";
 import {
   ElementIconCircle,
   IconSize,
 } from "src/ui/base/ElementIconCircle/ElementIconCircle";
-import { commify } from "ethers/lib/utils";
-import { t } from "ttag";
-import classNames from "classnames";
+import useClaimableAmount from "./useClaimableAmount";
 
 interface ClaimAmountCardProps {
-  amount: number | string;
   label?: string;
   className?: string;
 }
 
 export default function ClaimAmountCard({
-  amount,
   label = t`Claimable voting power`,
   className,
 }: ClaimAmountCardProps): ReactElement {
+  const claimableAmount = useClaimableAmount();
   return (
     <div
       className={classNames(
@@ -31,7 +31,7 @@ export default function ClaimAmountCard({
       <div className="flex items-center justify-center gap-3">
         <ElementIconCircle className="bg-paleLily" size={IconSize.LARGE} />
         <p className="text-5xl font-semibold text-principalRoyalBlue">
-          {t`${commify(amount)} ELFI`}
+          {t`${commify(claimableAmount)} ELFI`}
         </p>
       </div>
     </div>

--- a/src/ui/zkclaim/EligibleCard.tsx
+++ b/src/ui/zkclaim/EligibleCard.tsx
@@ -5,15 +5,18 @@ import { ButtonVariant } from "src/ui/base/Button/styles";
 import H2 from "src/ui/base/H2/H2";
 import ClaimAmountCard from "./ClaimAmountCard";
 import { t } from "ttag";
+import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
 
 interface EligibleCardProps {
   className?: string;
+  contract: PrivateAirdrop | undefined;
   onPreviousStep?: () => void;
   onNextStep?: () => void;
 }
 
 export default function EligibleCard({
   className,
+  contract,
   onPreviousStep,
   onNextStep,
 }: EligibleCardProps): ReactElement {
@@ -23,7 +26,7 @@ export default function EligibleCard({
         <div className="mb-12 text-center text-white sm:items-center sm:px-10 sm:text-center md:px-32">
           <h1 className="mb-2 text-3xl font-semibold">{t`Congratulations!`}</h1>
           <H2 className="mb-10 text-2xl text-votingGreen">{t`You're eligible for this Airdrop`}</H2>
-          <ClaimAmountCard />
+          <ClaimAmountCard contract={contract} />
         </div>
         <div className="flex justify-between">
           {onPreviousStep && (

--- a/src/ui/zkclaim/EligibleCard.tsx
+++ b/src/ui/zkclaim/EligibleCard.tsx
@@ -12,9 +12,6 @@ interface EligibleCardProps {
   onNextStep?: () => void;
 }
 
-// PLACEHOLDER
-const ELFI_TOKEN_AMOUNT = "10000.0";
-
 export default function EligibleCard({
   className,
   onPreviousStep,
@@ -26,7 +23,7 @@ export default function EligibleCard({
         <div className="mb-12 text-center text-white sm:items-center sm:px-10 sm:text-center md:px-32">
           <h1 className="mb-2 text-3xl font-semibold">{t`Congratulations!`}</h1>
           <H2 className="mb-10 text-2xl text-votingGreen">{t`You're eligible for this Airdrop`}</H2>
-          <ClaimAmountCard amount={ELFI_TOKEN_AMOUNT} />
+          <ClaimAmountCard />
         </div>
         <div className="flex justify-between">
           {onPreviousStep && (

--- a/src/ui/zkclaim/TransactionCard.tsx
+++ b/src/ui/zkclaim/TransactionCard.tsx
@@ -25,6 +25,7 @@ import { isValidAddress } from "src/base/isValidAddress";
 import { Spinner } from "src/ui/base/Spinner/Spinner";
 import { pedersenHash, toHex } from "zkp-merkle-airdrop-lib";
 import useClaimableAmount from "./useClaimableAmount";
+import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
 
 interface TransactionCardProps {
   className?: string;
@@ -32,6 +33,7 @@ interface TransactionCardProps {
   provider: Provider | undefined;
   signer: Signer | undefined;
   isReady: boolean;
+  contract: PrivateAirdrop | undefined;
   generateProof: () => Promise<string> | undefined;
   nullifier: string | undefined;
   delegateAddress: string;
@@ -46,6 +48,7 @@ export default function TransactionCard({
   provider,
   signer,
   isReady,
+  contract,
   generateProof,
   nullifier,
   delegateAddress,
@@ -55,14 +58,14 @@ export default function TransactionCard({
 }: TransactionCardProps): ReactElement {
   const [isWalletDialogOpen, setWalletDialogOpen] = useState(false);
   const onCloseWalletDialog = useCallback(() => setWalletDialogOpen(false), []);
-  const claimableAmount = useClaimableAmount();
+  const claimableAmount = useClaimableAmount(contract);
   const formattedAddress = useFormattedWalletAddress(delegateAddress, provider);
   const delegateLabel =
     getFeaturedDelegate(delegateAddress)?.name || formattedAddress;
   const [isTransactionPending, setIsTransactionPending] = useState(false);
   const [success, setSuccess] = useState(false);
   const toastIdRef = useRef<string>();
-  const { mutate: claimAndDelegate } = useClaimAndDelegate(signer, {
+  const { mutate: claimAndDelegate } = useClaimAndDelegate(signer, contract, {
     onError: (e) => {
       toast.error(e.message, { id: toastIdRef.current });
     },

--- a/src/ui/zkclaim/TransactionCard.tsx
+++ b/src/ui/zkclaim/TransactionCard.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement, useCallback, useState } from "react";
+import React, { ReactElement, useCallback, useRef, useState } from "react";
 import { Signer } from "ethers";
+import { Provider } from "@ethersproject/providers";
+import toast from "react-hot-toast";
 import Card, { CardVariant } from "src/ui/base/Card/Card";
 import {
   ElementIconCircle,
@@ -14,29 +16,38 @@ import { getFeaturedDelegate } from "src/elf/delegate/isFeaturedDelegate";
 import { WalletJazzicon } from "src/ui/wallet/WalletJazzicon";
 import { ConnectWalletDialog } from "src/ui/wallet/ConnectWalletDialog";
 import { commify } from "ethers/lib/utils";
-import { t } from "ttag";
+import { jt, t } from "ttag";
 import { useFormattedWalletAddress } from "src/ui/ethereum/useFormattedWalletAddress";
-import { Provider } from "@ethersproject/providers";
+import ExternalLink from "src/ui/base/ExternalLink/ExternalLink";
+import { ETHERSCAN_TRANSACTION_DOMAIN } from "src/elf-etherscan/domain";
+import { useClaimAndDelegate } from "./useClaimAndDelegate";
+import { isValidAddress } from "src/base/isValidAddress";
+import { Spinner } from "src/ui/base/Spinner/Spinner";
+import { pedersenHash, toHex } from "zkp-merkle-airdrop-lib";
+import useClaimableAmount from "./useClaimableAmount";
 
 interface TransactionCardProps {
   className?: string;
-  account?: string;
-  provider?: Provider;
-  signer?: Signer;
+  account: string | null | undefined;
+  provider: Provider | undefined;
+  signer: Signer | undefined;
+  isReady: boolean;
+  generateProof: () => Promise<string> | undefined;
+  nullifier: string | undefined;
   delegateAddress: string;
   onPreviousStep?: () => void;
   onSuccess?: () => void;
   onNextStep?: () => void;
 }
 
-// PLACEHOLDER
-const ELFI_TOKEN_AMOUNT = "10000.0";
-
 export default function TransactionCard({
   className,
   account,
   provider,
   signer,
+  isReady,
+  generateProof,
+  nullifier,
   delegateAddress,
   onPreviousStep,
   onSuccess,
@@ -44,15 +55,49 @@ export default function TransactionCard({
 }: TransactionCardProps): ReactElement {
   const [isWalletDialogOpen, setWalletDialogOpen] = useState(false);
   const onCloseWalletDialog = useCallback(() => setWalletDialogOpen(false), []);
-  const [success, setSuccess] = useState(false);
+  const claimableAmount = useClaimableAmount();
   const formattedAddress = useFormattedWalletAddress(delegateAddress, provider);
   const delegateLabel =
     getFeaturedDelegate(delegateAddress)?.name || formattedAddress;
+  const [isTransactionPending, setIsTransactionPending] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const toastIdRef = useRef<string>();
+  const { mutate: claimAndDelegate } = useClaimAndDelegate(signer, {
+    onError: (e) => {
+      toast.error(e.message, { id: toastIdRef.current });
+    },
+    onTransactionSubmitted: (tx) => {
+      const etherscanLink = (
+        <ExternalLink
+          href={`${ETHERSCAN_TRANSACTION_DOMAIN}/${tx.hash}`}
+          text={t`View on etherscan`}
+          className="text-principalRoyalBlue"
+        />
+      );
+
+      toastIdRef.current = toast.loading(
+        <div>{jt`Confirming transaction... ${etherscanLink}`}</div>,
+      );
+    },
+    onTransactionMined: () => {
+      toast.success(t`Transaction successfully confirmed`, {
+        id: toastIdRef.current,
+      });
+      setIsTransactionPending(false);
+      setSuccess(true);
+      onSuccess?.();
+    },
+  });
 
   const handleConfirm = () => {
-    // handle transaction
-    setSuccess(true);
-    onSuccess?.();
+    setIsTransactionPending(true);
+    generateProof()?.then((proof) => {
+      claimAndDelegate([
+        proof,
+        toHex(pedersenHash(BigInt(nullifier as string))),
+        delegateAddress,
+      ]);
+    });
   };
   return (
     <>
@@ -62,7 +107,7 @@ export default function TransactionCard({
       />
       <Card className={className} variant={CardVariant.BLUE}>
         <div className="flex flex-col gap-2 p-2 text-white sm:px-6 sm:py-4">
-          <div className="mb-12 text-center text-white sm:items-center sm:px-10 sm:text-center md:px-32">
+          <div className="mb-8 text-center text-white sm:items-center sm:px-10 sm:text-center md:px-32">
             <h1 className="mb-10 text-3xl font-semibold">{t`Review Transaction`}</h1>
             <div className="flex min-w-full flex-col gap-10 rounded-lg bg-white px-14 pt-8 pb-10 text-center shadow-[0_0_52px_rgba(143,216,231,.7)]">
               <div>
@@ -75,7 +120,7 @@ export default function TransactionCard({
                     size={IconSize.MEDIUM}
                   />
                   <p className="text-3xl font-semibold text-principalRoyalBlue">
-                    {t`${commify(ELFI_TOKEN_AMOUNT)} ELFI`}
+                    {t`${commify(claimableAmount)} ELFI`}
                   </p>
                 </div>
               </div>
@@ -98,6 +143,7 @@ export default function TransactionCard({
             </div>
           </div>
 
+          <p className="mb-2 w-0 min-w-full text-sm italic text-white/80">{t`Note: this transaction requires a ZK proof generated from your key and secret. Generating the proof could take up to 30 seconds before the transaction is initiated.`}</p>
           <div className="flex justify-between">
             {onPreviousStep && (
               <Button
@@ -108,6 +154,7 @@ export default function TransactionCard({
                 {t`Back`}
               </Button>
             )}
+
             {success ? (
               <>
                 <Tag intent={Intent.SUCCESS}>
@@ -129,8 +176,17 @@ export default function TransactionCard({
                 className="px-12"
                 variant={ButtonVariant.GRADIENT}
                 onClick={handleConfirm}
+                disabled={
+                  !isReady ||
+                  !isValidAddress(delegateAddress) ||
+                  isTransactionPending
+                }
               >
-                {t`Confirm transaction`}
+                {!isReady || isTransactionPending ? (
+                  <Spinner />
+                ) : (
+                  t`Confirm transaction`
+                )}
               </Button>
             ) : (
               <Button

--- a/src/ui/zkclaim/ZKClaimPage.tsx
+++ b/src/ui/zkclaim/ZKClaimPage.tsx
@@ -22,6 +22,7 @@ import { StepDivider } from "src/ui/base/Steps/StepDivider";
 import Steps from "src/ui/base/Steps/Steps";
 import { t } from "ttag";
 import useAddressScreening from "./useAddressScreening";
+import useAlreadyClaimed from "./useAlreadyClaimed";
 
 export enum Step {
   LOOKUP = "lookup",
@@ -39,7 +40,7 @@ export default function ZKClaimPage(): ReactElement {
   const [keySecretPair, setKeySecretPair] = useState<[string, string]>();
   const key = keySecretPair?.[0];
   const secret = keySecretPair?.[1];
-  const [alreadyClaimed, setAlreadyClaimed] = useState(false);
+  const alreadyClaimed = useAlreadyClaimed(key);
   const [delegateAddress, setDelegateAddress] = useState<string>();
   const {
     generate: generateProof,

--- a/src/ui/zkclaim/ZKClaimPage.tsx
+++ b/src/ui/zkclaim/ZKClaimPage.tsx
@@ -44,11 +44,8 @@ export default function ZKClaimPage(): ReactElement {
   const [delegateAddress, setDelegateAddress] = useState<string>();
   const {
     generate: generateProof,
-    proof,
     isEligible,
     isReady,
-    error: proofError,
-    isGenerating,
   } = useZKProof({
     key,
     secret,
@@ -193,9 +190,11 @@ export default function ZKClaimPage(): ReactElement {
         <TransactionCard
           className={getStepClassName(Step.TRANSACTION)}
           provider={library}
-          // avoiding passing null with `|| undefined`
-          account={account || undefined}
+          account={account}
           signer={signer}
+          isReady={isReady}
+          generateProof={generateProof}
+          nullifier={key}
           delegateAddress={delegateAddress}
           onPreviousStep={goToPreviousStep}
           onSuccess={goToNextStep}

--- a/src/ui/zkclaim/ZKClaimPage.tsx
+++ b/src/ui/zkclaim/ZKClaimPage.tsx
@@ -40,17 +40,18 @@ export default function ZKClaimPage(): ReactElement {
   const [keySecretPair, setKeySecretPair] = useState<[string, string]>();
   const key = keySecretPair?.[0];
   const secret = keySecretPair?.[1];
-  const alreadyClaimed = useAlreadyClaimed(key);
   const [delegateAddress, setDelegateAddress] = useState<string>();
   const {
     generate: generateProof,
     isEligible,
     isReady,
+    contract,
   } = useZKProof({
     key,
     secret,
     account: account || undefined,
   });
+  const alreadyClaimed = useAlreadyClaimed(key, contract);
   const { pass } = useAddressScreening(account);
 
   const {
@@ -159,12 +160,16 @@ export default function ZKClaimPage(): ReactElement {
           onTryAgain={goToPreviousStep}
         />
       ) : alreadyClaimed ? (
-        <AlreadyClaimedCard className={getStepClassName(Step.ELIGIBILITY)} />
+        <AlreadyClaimedCard
+          className={getStepClassName(Step.ELIGIBILITY)}
+          contract={contract}
+        />
       ) : (
         <EligibleCard
           className={getStepClassName(Step.ELIGIBILITY)}
           onPreviousStep={goToPreviousStep}
           onNextStep={goToNextStep}
+          contract={contract}
         />
       )}
 
@@ -193,6 +198,7 @@ export default function ZKClaimPage(): ReactElement {
           account={account}
           signer={signer}
           isReady={isReady}
+          contract={contract}
           generateProof={generateProof}
           nullifier={key}
           delegateAddress={delegateAddress}

--- a/src/ui/zkclaim/isValidKeyOrSecret.ts
+++ b/src/ui/zkclaim/isValidKeyOrSecret.ts
@@ -1,0 +1,5 @@
+export default function isValidKeyOrSecret(
+  keyOrSecret: string | undefined,
+): boolean {
+  return keyOrSecret ? /0x\d{64}/.test(keyOrSecret) : false;
+}

--- a/src/ui/zkclaim/useAlreadyClaimed.ts
+++ b/src/ui/zkclaim/useAlreadyClaimed.ts
@@ -1,14 +1,20 @@
 import { pedersenHash, toHex } from "zkp-merkle-airdrop-lib";
 import { useSmartContractReadCall } from "@elementfi/react-query-typechain";
-import { privateAirdropContract } from "src/elf/contracts";
+import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
+import isValidKeyOrSecret from "./isValidKeyOrSecret";
 
-export default function useAlreadyClaimed(key?: string): boolean | undefined {
+export default function useAlreadyClaimed(
+  key: string | undefined,
+  contract: PrivateAirdrop | undefined,
+): boolean | undefined {
   const { data: alreadyClaimed } = useSmartContractReadCall(
-    privateAirdropContract,
+    contract,
     "nullifierSpent",
     {
-      callArgs: [toHex(pedersenHash(BigInt(key || "")))],
-      enabled: !!key,
+      callArgs: isValidKeyOrSecret(key)
+        ? [toHex(pedersenHash(BigInt(key as string)))]
+        : [""],
+      enabled: isValidKeyOrSecret(key),
     },
   );
 

--- a/src/ui/zkclaim/useAlreadyClaimed.ts
+++ b/src/ui/zkclaim/useAlreadyClaimed.ts
@@ -1,0 +1,16 @@
+import { pedersenHash, toHex } from "zkp-merkle-airdrop-lib";
+import { useSmartContractReadCall } from "@elementfi/react-query-typechain";
+import { privateAirdropContract } from "src/elf/contracts";
+
+export default function useAlreadyClaimed(key?: string): boolean | undefined {
+  const { data: alreadyClaimed } = useSmartContractReadCall(
+    privateAirdropContract,
+    "nullifierSpent",
+    {
+      callArgs: [toHex(pedersenHash(BigInt(key as string)))],
+      enabled: !!key,
+    },
+  );
+
+  return alreadyClaimed;
+}

--- a/src/ui/zkclaim/useAlreadyClaimed.ts
+++ b/src/ui/zkclaim/useAlreadyClaimed.ts
@@ -7,7 +7,7 @@ export default function useAlreadyClaimed(key?: string): boolean | undefined {
     privateAirdropContract,
     "nullifierSpent",
     {
-      callArgs: [toHex(pedersenHash(BigInt(key as string)))],
+      callArgs: [toHex(pedersenHash(BigInt(key || "")))],
       enabled: !!key,
     },
   );

--- a/src/ui/zkclaim/useClaimAndDelegate.ts
+++ b/src/ui/zkclaim/useClaimAndDelegate.ts
@@ -1,0 +1,29 @@
+import { UseMutationResult } from "react-query";
+
+import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
+import { ContractReceipt, Signer } from "ethers";
+import { privateAirdropContract } from "src/elf/contracts";
+import {
+  useSmartContractTransaction,
+  UseSmartContractTransactionOptions,
+} from "@elementfi/react-query-typechain";
+
+export function useClaimAndDelegate(
+  signer: Signer | undefined,
+  options?: UseSmartContractTransactionOptions<
+    PrivateAirdrop,
+    "claimAirdropAndDelegate"
+  >,
+): UseMutationResult<
+  ContractReceipt | undefined,
+  unknown,
+  Parameters<PrivateAirdrop["claimAirdropAndDelegate"]>
+> {
+  const claimAndDelegate = useSmartContractTransaction(
+    privateAirdropContract,
+    "claimAirdropAndDelegate",
+    signer,
+    options,
+  );
+  return claimAndDelegate;
+}

--- a/src/ui/zkclaim/useClaimAndDelegate.ts
+++ b/src/ui/zkclaim/useClaimAndDelegate.ts
@@ -2,7 +2,6 @@ import { UseMutationResult } from "react-query";
 
 import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
 import { ContractReceipt, Signer } from "ethers";
-import { privateAirdropContract } from "src/elf/contracts";
 import {
   useSmartContractTransaction,
   UseSmartContractTransactionOptions,
@@ -10,6 +9,7 @@ import {
 
 export function useClaimAndDelegate(
   signer: Signer | undefined,
+  contract: PrivateAirdrop | undefined,
   options?: UseSmartContractTransactionOptions<
     PrivateAirdrop,
     "claimAirdropAndDelegate"
@@ -20,7 +20,7 @@ export function useClaimAndDelegate(
   Parameters<PrivateAirdrop["claimAirdropAndDelegate"]>
 > {
   const claimAndDelegate = useSmartContractTransaction(
-    privateAirdropContract,
+    contract,
     "claimAirdropAndDelegate",
     signer,
     options,

--- a/src/ui/zkclaim/useClaimableAmount.ts
+++ b/src/ui/zkclaim/useClaimableAmount.ts
@@ -1,12 +1,17 @@
+import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
 import { useSmartContractReadCall } from "@elementfi/react-query-typechain";
 import { formatEther } from "@ethersproject/units";
-import { privateAirdropContract } from "src/elf/contracts";
 
-export default function useClaimableAmount(): string {
+export default function useClaimableAmount(
+  contract: PrivateAirdrop | undefined,
+): string {
   const { data: ClaimableAmount } = useSmartContractReadCall(
-    privateAirdropContract,
+    contract,
     "amountPerRedemption",
+    {
+      enabled: !!contract,
+    },
   );
 
-  return formatEther(ClaimableAmount || 0);
+  return formatEther(ClaimableAmount || 0).replace(/(\.\d{3}).+/, "$1");
 }

--- a/src/ui/zkclaim/useClaimableAmount.ts
+++ b/src/ui/zkclaim/useClaimableAmount.ts
@@ -1,0 +1,12 @@
+import { useSmartContractReadCall } from "@elementfi/react-query-typechain";
+import { formatEther } from "@ethersproject/units";
+import { privateAirdropContract } from "src/elf/contracts";
+
+export default function useClaimableAmount(): string {
+  const { data: ClaimableAmount } = useSmartContractReadCall(
+    privateAirdropContract,
+    "amountPerRedemption",
+  );
+
+  return formatEther(ClaimableAmount || 0);
+}

--- a/src/ui/zkclaim/useZKProof.ts
+++ b/src/ui/zkclaim/useZKProof.ts
@@ -56,7 +56,7 @@ export interface UseZKProofProps {
 }
 
 interface UseZKProof extends ProofState {
-  generate: () => void;
+  generate: () => Promise<string> | undefined;
   isEligible: boolean;
   isReady: boolean;
 }
@@ -118,7 +118,7 @@ export default function useZKProof({
   const generate = useCallback(() => {
     if (isReady && isEligible && key && secret && account) {
       dispatch({ type: "startGenerating" });
-      generateProofCallData(
+      return generateProofCallData(
         merkleTree,
         BigInt(key),
         BigInt(secret),
@@ -128,9 +128,11 @@ export default function useZKProof({
       )
         .then((proof) => {
           dispatch({ type: "setProof", payload: proof });
+          return proof;
         })
         .catch((err) => {
           dispatch({ type: "setError", payload: err });
+          return err?.message || "";
         });
     }
   }, [

--- a/src/ui/zkclaim/useZKProof.ts
+++ b/src/ui/zkclaim/useZKProof.ts
@@ -6,6 +6,15 @@ import {
   toHex,
 } from "zkp-merkle-airdrop-lib";
 import { useQuery } from "react-query";
+import {
+  discordTier1PrivateAirdropContract,
+  // discordTier2PrivateAirdropContract,
+  // discordTier3PrivateAirdropContract,
+  githubTier1PrivateAirdropContract,
+  githubTier2PrivateAirdropContract,
+  githubTier3PrivateAirdropContract,
+} from "src/elf/contracts";
+import { PrivateAirdrop } from "@elementfi/elf-council-typechain";
 
 // TODO: Move cdn base url to environment variable
 const cdnUrl = `https://elementfi.s3.us-east-2.amazonaws.com/rewards/${
@@ -55,7 +64,12 @@ export interface UseZKProofProps {
   account?: string;
 }
 
-interface UseZKProof extends ProofState {
+export interface MerkleTreeInfo {
+  merkleTree: MerkleTree;
+  contract: PrivateAirdrop;
+}
+
+interface UseZKProof extends ProofState, Partial<MerkleTreeInfo> {
   generate: () => Promise<string> | undefined;
   isEligible: boolean;
   isReady: boolean;
@@ -71,14 +85,67 @@ export default function useZKProof({
   });
 
   // fetch required files
-  const { data: merkleTree } = useQuery({
-    queryKey: "zk-merkle-tree",
+  // TODO: fetch all trees
+  const { data: githubTier1MerkleTree } = useQuery({
+    queryKey: "github-merkle-tree-1",
     queryFn: async () =>
-      fetch(`${cdnUrl}/merkle_tree_storage_string.txt`)
+      fetch(`${cdnUrl}/merkle/${githubTier1PrivateAirdropContract.address}.txt`)
         .then((res) => res.text())
         .then((mtss) => MerkleTree.createFromStorageString(mtss)),
     staleTime: Infinity,
   });
+  const { data: githubTier2MerkleTree } = useQuery({
+    queryKey: "github-merkle-tree-2",
+    queryFn: async () =>
+      fetch(`${cdnUrl}/merkle/${githubTier2PrivateAirdropContract.address}.txt`)
+        .then((res) => res.text())
+        .then((mtss) => MerkleTree.createFromStorageString(mtss)),
+    staleTime: Infinity,
+  });
+  const { data: githubTier3MerkleTree } = useQuery({
+    queryKey: "github-merkle-tree-3",
+    queryFn: async () =>
+      fetch(`${cdnUrl}/merkle/${githubTier3PrivateAirdropContract.address}.txt`)
+        .then((res) => res.text())
+        .then((mtss) => MerkleTree.createFromStorageString(mtss)),
+    staleTime: Infinity,
+  });
+  const { data: discordTier1MerkleTree } = useQuery({
+    queryKey: "discord-merkle-tree-1",
+    queryFn: async () =>
+      fetch(
+        `${cdnUrl}/merkle/${discordTier1PrivateAirdropContract.address}.txt`,
+      )
+        .then((res) => res.text())
+        .then((mtss) => MerkleTree.createFromStorageString(mtss)),
+    staleTime: Infinity,
+  });
+  // const { data: discordTier2MerkleTree } = useQuery({
+  //   queryKey: "discord-merkle-tree-2",
+  //   queryFn: async () =>
+  //     fetch(`${cdnUrl}/merkle/${discordTier2PrivateAirdropContract.address}.txt`)
+  //       .then((res) => res.text())
+  //       .then((mtss) => MerkleTree.createFromStorageString(mtss)),
+  //   staleTime: Infinity,
+  // });
+  // const { data: discordTier3MerkleTree } = useQuery({
+  //   queryKey: "discord-merkle-tree-3",
+  //   queryFn: async () =>
+  //     fetch(`${cdnUrl}/merkle/${discordTier3PrivateAirdropContract.address}.txt`)
+  //       .then((res) => res.text())
+  //       .then((mtss) => MerkleTree.createFromStorageString(mtss)),
+  //   staleTime: Infinity,
+  // });
+  const treesReady = !!(
+    (
+      githubTier1MerkleTree &&
+      githubTier2MerkleTree &&
+      githubTier3MerkleTree &&
+      discordTier1MerkleTree
+    ) //&&
+    // discordTier2MerkleTree &&
+    // discordTier3MerkleTree
+  );
   const { data: wasmBuffer } = useQuery({
     queryKey: "zk-wasm-buffer",
     queryFn: () =>
@@ -97,31 +164,79 @@ export default function useZKProof({
   });
 
   // set isEligible when the key, secret, and/or merkleTree change
-  const isEligible = useMemo(() => {
-    if (key && secret && merkleTree) {
+  const merkleTreeInfo = useMemo<MerkleTreeInfo | undefined>(() => {
+    if (key && secret && treesReady) {
       let commitment: string;
 
       // OK to catch, as it throws in the case of being not eligible
       try {
         commitment = toHex(pedersenHashConcat(BigInt(key), BigInt(secret)));
       } catch (e) {
-        return false;
+        return undefined;
       }
 
-      return merkleTree.leafExists(BigInt(commitment));
+      const merkleTrees = [
+        {
+          merkleTree: githubTier1MerkleTree,
+          contract: githubTier1PrivateAirdropContract,
+        },
+        {
+          merkleTree: githubTier2MerkleTree,
+          contract: githubTier2PrivateAirdropContract,
+        },
+        {
+          merkleTree: githubTier3MerkleTree,
+          contract: githubTier3PrivateAirdropContract,
+        },
+        {
+          merkleTree: discordTier1MerkleTree,
+          contract: discordTier1PrivateAirdropContract,
+        },
+        // {
+        //   merkleTree: discordTier2MerkleTree,
+        //   contract: discordTier2PrivateAirdropContract,
+        // },
+        // {
+        //   merkleTree: discordTier3MerkleTree,
+        //   contract: discordTier3PrivateAirdropContract,
+        // },
+      ];
+      for (const treeInfo of merkleTrees) {
+        const leafExists = treeInfo.merkleTree.leafExists(BigInt(commitment));
+        if (leafExists) {
+          return treeInfo;
+        }
+      }
     }
-    return false;
-  }, [key, secret, merkleTree]);
+  }, [
+    key,
+    secret,
+    treesReady,
+    githubTier1MerkleTree,
+    githubTier2MerkleTree,
+    githubTier3MerkleTree,
+    discordTier1MerkleTree,
+    // discordTier2MerkleTree,
+    // discordTier3MerkleTree,
+  ]);
 
-  const isReady = !!(merkleTree && wasmBuffer && zkeyBuffer);
+  const isReady = !!(treesReady && wasmBuffer && zkeyBuffer);
 
   const generate = useCallback(() => {
-    if (isReady && isEligible && key && secret && account) {
+    if (isReady && merkleTreeInfo && key && secret && account) {
       dispatch({ type: "startGenerating" });
       return generateProofCallData(
-        merkleTree,
-        BigInt(key),
-        BigInt(secret),
+        merkleTreeInfo?.merkleTree,
+        // the last 2 characters represent the MSB which are removed by the
+        // pedersenHash function when creating the commitment (public ID). To
+        // generate a valid proof, they need to be removed here too.
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        BigInt(key.slice(0, 64)),
+        // the last 2 characters represent the MSB which are removed by the
+        // pedersenHash function when creating the commitment (public ID). To
+        // generate a valid proof, they need to be removed here too.
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        BigInt(secret.slice(0, 64)),
         account,
         wasmBuffer,
         zkeyBuffer,
@@ -135,21 +250,13 @@ export default function useZKProof({
           return err?.message || "";
         });
     }
-  }, [
-    key,
-    secret,
-    account,
-    merkleTree,
-    wasmBuffer,
-    zkeyBuffer,
-    isEligible,
-    isReady,
-  ]);
+  }, [key, secret, account, merkleTreeInfo, wasmBuffer, zkeyBuffer, isReady]);
 
   return {
     generate,
     isReady,
-    isEligible,
+    isEligible: !!merkleTreeInfo,
     ...state,
+    ...merkleTreeInfo,
   };
 }

--- a/src/ui/zkclaim/useZKProof.ts
+++ b/src/ui/zkclaim/useZKProof.ts
@@ -8,8 +8,8 @@ import {
 import { useQuery } from "react-query";
 import {
   discordTier1PrivateAirdropContract,
-  // discordTier2PrivateAirdropContract,
-  // discordTier3PrivateAirdropContract,
+  discordTier2PrivateAirdropContract,
+  discordTier3PrivateAirdropContract,
   githubTier1PrivateAirdropContract,
   githubTier2PrivateAirdropContract,
   githubTier3PrivateAirdropContract,
@@ -120,31 +120,33 @@ export default function useZKProof({
         .then((mtss) => MerkleTree.createFromStorageString(mtss)),
     staleTime: Infinity,
   });
-  // const { data: discordTier2MerkleTree } = useQuery({
-  //   queryKey: "discord-merkle-tree-2",
-  //   queryFn: async () =>
-  //     fetch(`${cdnUrl}/merkle/${discordTier2PrivateAirdropContract.address}.txt`)
-  //       .then((res) => res.text())
-  //       .then((mtss) => MerkleTree.createFromStorageString(mtss)),
-  //   staleTime: Infinity,
-  // });
-  // const { data: discordTier3MerkleTree } = useQuery({
-  //   queryKey: "discord-merkle-tree-3",
-  //   queryFn: async () =>
-  //     fetch(`${cdnUrl}/merkle/${discordTier3PrivateAirdropContract.address}.txt`)
-  //       .then((res) => res.text())
-  //       .then((mtss) => MerkleTree.createFromStorageString(mtss)),
-  //   staleTime: Infinity,
-  // });
+  const { data: discordTier2MerkleTree } = useQuery({
+    queryKey: "discord-merkle-tree-2",
+    queryFn: async () =>
+      fetch(
+        `${cdnUrl}/merkle/${discordTier2PrivateAirdropContract.address}.txt`,
+      )
+        .then((res) => res.text())
+        .then((mtss) => MerkleTree.createFromStorageString(mtss)),
+    staleTime: Infinity,
+  });
+  const { data: discordTier3MerkleTree } = useQuery({
+    queryKey: "discord-merkle-tree-3",
+    queryFn: async () =>
+      fetch(
+        `${cdnUrl}/merkle/${discordTier3PrivateAirdropContract.address}.txt`,
+      )
+        .then((res) => res.text())
+        .then((mtss) => MerkleTree.createFromStorageString(mtss)),
+    staleTime: Infinity,
+  });
   const treesReady = !!(
-    (
-      githubTier1MerkleTree &&
-      githubTier2MerkleTree &&
-      githubTier3MerkleTree &&
-      discordTier1MerkleTree
-    ) //&&
-    // discordTier2MerkleTree &&
-    // discordTier3MerkleTree
+    githubTier1MerkleTree &&
+    githubTier2MerkleTree &&
+    githubTier3MerkleTree &&
+    discordTier1MerkleTree &&
+    discordTier2MerkleTree &&
+    discordTier3MerkleTree
   );
   const { data: wasmBuffer } = useQuery({
     queryKey: "zk-wasm-buffer",
@@ -192,14 +194,14 @@ export default function useZKProof({
           merkleTree: discordTier1MerkleTree,
           contract: discordTier1PrivateAirdropContract,
         },
-        // {
-        //   merkleTree: discordTier2MerkleTree,
-        //   contract: discordTier2PrivateAirdropContract,
-        // },
-        // {
-        //   merkleTree: discordTier3MerkleTree,
-        //   contract: discordTier3PrivateAirdropContract,
-        // },
+        {
+          merkleTree: discordTier2MerkleTree,
+          contract: discordTier2PrivateAirdropContract,
+        },
+        {
+          merkleTree: discordTier3MerkleTree,
+          contract: discordTier3PrivateAirdropContract,
+        },
       ];
       for (const treeInfo of merkleTrees) {
         const leafExists = treeInfo.merkleTree.leafExists(BigInt(commitment));
@@ -216,8 +218,8 @@ export default function useZKProof({
     githubTier2MerkleTree,
     githubTier3MerkleTree,
     discordTier1MerkleTree,
-    // discordTier2MerkleTree,
-    // discordTier3MerkleTree,
+    discordTier2MerkleTree,
+    discordTier3MerkleTree,
   ]);
 
   const isReady = !!(treesReady && wasmBuffer && zkeyBuffer);


### PR DESCRIPTION
- Added the contract to `contracts.ts`. I left the address blank for now.
- Added a `useClaimableAmount` hook
- Added a `useAlreadyClaimed` hook
- Added a `useClaimAndDelegate` hook
- Refactored the `generate` function of the `useZKProof` hook to return the `generateProofCallData` promise so that the `TransactionCard` can use `.then()` on it.
- Refactored the `TransactionCard` to handle proof generation and call the contract.