### PR TITLE
fix useQueryVotePower, useZKProof

### DIFF
--- a/src/ui/zkclaim/TransactionCard.tsx
+++ b/src/ui/zkclaim/TransactionCard.tsx
@@ -92,15 +92,20 @@ export default function TransactionCard({
     },
   });
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     setIsTransactionPending(true);
-    generateProof()?.then((proof) => {
-      claimAndDelegate([
-        proof,
-        toHex(pedersenHash(BigInt(nullifier as string))),
-        delegateAddress,
-      ]);
-    });
+    try {
+      const proof = await generateProof();
+      if (proof) {
+        claimAndDelegate([
+          proof,
+          toHex(pedersenHash(BigInt(nullifier as string))),
+          delegateAddress,
+        ]);
+      }
+    } catch (error) {
+      console.log(error);
+    }
   };
   return (
     <>


### PR DESCRIPTION
Adds some hacks to useQueryVotePower so that we don't flood the console with errors. The errors were red herrings that people were reporting for the zk claim.  

Adds some success checks when downloading the merkle trees and the circuits.  The circuits also now download _after_ the merkle trees to make sure they don't block them since the circuit files are large.