### PR TITLE
subtract foundation and team accounts from circulating vote power calculation

### DIFF
--- a/src/ui/voting/useLockingVaultBalance.ts
+++ b/src/ui/voting/useLockingVaultBalance.ts
@@ -4,10 +4,7 @@ import { lockingVaultContract } from "src/elf/contracts";
 import {} from "src/ui/voting/useQueryVotePower";
 
 /**
- * Use this to get the current vote power.
- *
- * Voting power can go stale if the current block is beyond the staleBlockLag +
- * atBlockNumber. In the case of stale voting power, this will return "0".
+ * Use this to get the amount deposited into the locking vault for an account.
  */
 export function useLockingVaultBalance(
   account: string | undefined | null,

--- a/src/ui/voting/useLockingVaultBalance.ts
+++ b/src/ui/voting/useLockingVaultBalance.ts
@@ -1,0 +1,22 @@
+import { useSmartContractReadCall } from "@elementfi/react-query-typechain";
+import { formatEther } from "ethers/lib/utils";
+import { lockingVaultContract } from "src/elf/contracts";
+import {} from "src/ui/voting/useQueryVotePower";
+
+/**
+ * Use this to get the current vote power.
+ *
+ * Voting power can go stale if the current block is beyond the staleBlockLag +
+ * atBlockNumber. In the case of stale voting power, this will return "0".
+ */
+export function useLockingVaultBalance(
+  account: string | undefined | null,
+): string {
+  // data is returned as [address, amount]
+  const { data } = useSmartContractReadCall(lockingVaultContract, "deposits", {
+    callArgs: [account as string],
+    enabled: !!account,
+  });
+  const balance = formatEther(data?.[1] || 0);
+  return balance;
+}

--- a/src/ui/voting/useVotingPowerForProtocol.tsx
+++ b/src/ui/voting/useVotingPowerForProtocol.tsx
@@ -1,27 +1,41 @@
-import {
-  useSmartContractEvents,
-  useSmartContractReadCall,
-} from "@elementfi/react-query-typechain";
+import { useMemo } from "react";
+
+import { useSmartContractEvents } from "@elementfi/react-query-typechain";
 import { BigNumber, ethers } from "ethers";
 import { formatEther } from "ethers/lib/utils";
-import { useMemo } from "react";
+
 import { addressesJson } from "src/elf-council-addresses";
 import { elementTokenContract, vestingContract } from "src/elf/contracts";
+import { useTokenBalanceOf } from "src/elf/token/useTokenBalanceOf";
+import { useLockingVaultBalance } from "src/ui/voting/useLockingVaultBalance";
 
 const { lockingVault } = addressesJson.addresses;
+
+// the following two addresses have tokens in the locking vault but they aren't used to vote so we
+// need to subtract them from calculation of the circulating voting power for the protocol:
+const foundationAddress = "0xFEaDB1F18386d0225a38E9c4bD1E9Ac52243dE99"; // foundation non voting contract
+const teamAddress = "0xcC46775f1dB1d697c176ed66698BA3C15394C3D4"; // team non voting contract
 
 export function useVotingPowerForProtocol(): number {
   // value in Eth
   const vestingVaultVotingPower = useVestingVaultVotingPower();
 
-  const { data: lockingVaultBalanceBN = BigNumber.from(0) } =
-    useSmartContractReadCall(elementTokenContract, "balanceOf", {
-      callArgs: [lockingVault],
-    });
+  const { data: lockingVaultBalanceBN } = useTokenBalanceOf(
+    elementTokenContract,
+    lockingVault,
+  );
+  const lockingVaultVotingPower = +formatEther(lockingVaultBalanceBN || 0);
 
-  const lockingVaultVotingPower = +formatEther(lockingVaultBalanceBN);
+  // get deposits for foundation and team in the locking vault.  they are delegated to the
+  // 0x0000...0001 address so they can't vote so we need to remove them from the total
+  const foundationBalance = useLockingVaultBalance(foundationAddress);
+  const teamBalance = useLockingVaultBalance(teamAddress);
 
-  const votingPower = +vestingVaultVotingPower + lockingVaultVotingPower;
+  const votingPower =
+    +vestingVaultVotingPower +
+    lockingVaultVotingPower -
+    +foundationBalance -
+    +teamBalance;
 
   return votingPower;
 }
@@ -32,7 +46,7 @@ function useVestingVaultVotingPower(): string {
     "VoteChange",
   );
 
-  return useMemo(() => {
+  const result = useMemo(() => {
     if (!events) {
       return "0";
     }
@@ -61,7 +75,8 @@ function useVestingVaultVotingPower(): string {
 
     const vestingVaultVotingPower = formatEther(vestingVaultVotingPowerBN);
     return vestingVaultVotingPower;
-    // events are immutable, only update if there are new events.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [events?.length]);
+
+  return result;
 }

--- a/src/ui/voting/useVotingPowerForProtocol.tsx
+++ b/src/ui/voting/useVotingPowerForProtocol.tsx
@@ -75,6 +75,7 @@ function useVestingVaultVotingPower(): string {
 
     const vestingVaultVotingPower = formatEther(vestingVaultVotingPowerBN);
     return vestingVaultVotingPower;
+    // events are immutable, only update if there are new events.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [events?.length]);
 


### PR DESCRIPTION
there are foundation and team amounts that have been put into the locking vault.  these should not be counted towards voting totals since they can't vote with them.  They are delegated to the 0x0000...0001 address.  This is a fix that subtracts their balances from the total.